### PR TITLE
Bump build number, revert to pip install

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,13 +10,14 @@ source:
   sha256: 6d3c559cb99785d4623cc39701dde56f083d09d3631840c601726bef83b74f0f
 build:
   noarch: python
-  number: 1
-  script: "{{ PYTHON }} -m pip install . -vv"
+  number: 2
+  script: "{{ PYTHON }} -m build . -vv"
 
 requirements:
   host:
     - python >=3.5
     - pip
+    - build
     - setuptools
   run:
     - python >=3.5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 6d3c559cb99785d4623cc39701dde56f083d09d3631840c601726bef83b74f0f
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:


### PR DESCRIPTION
Pip install will now build the wheel as well as installing it instead of relying on a wheel being available externally.