### PR TITLE
Rename 'build' package to 'python-build'

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
   host:
     - python >=3.5
     - pip
-    - build
+    - python-build
     - setuptools
   run:
     - python >=3.5


### PR DESCRIPTION
Per the conda-forge linter, the Python build package has been renamed to python-build.