### PR TITLE
Bump build number, make sure we're using pip install

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 6d3c559cb99785d4623cc39701dde56f083d09d3631840c601726bef83b74f0f
 build:
   noarch: python
-  number: 0
+  number: 3
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:


### PR DESCRIPTION
I thought we were already using pip install on main.  Maybe I was wrong and something got missed?

